### PR TITLE
Fixed search engines added with empty parameters

### DIFF
--- a/API.php
+++ b/API.php
@@ -98,6 +98,8 @@ class API extends \Piwik\Plugin\API
 
         if (!empty($parameters)) {
             $parameters = explode(',', $parameters);
+        } else {
+            $parameters = array();
         }
 
         $engines        = $this->model->getUserDefinedSearchEngines();

--- a/Model.php
+++ b/Model.php
@@ -164,13 +164,13 @@ class Model
         $searchEngineInfos = $this->getSearchEngines();
 
         foreach ($searchEngineInfos AS $url => $infos) {
-
+            $parameters = !is_array($infos['params']) ? $infos['params'] : implode(', ', $infos['params']);
             if (empty($mergedSearchInfos[$infos['name']])) {
                 $mergedSearchInfos[$infos['name']] = [];
             }
             $mergedSearchInfos[$infos['name']][] = [
                 'url'        => $url,
-                'parameters' => implode(', ', $infos['params']),
+                'parameters' => $parameters,
                 'backlink'   => !empty($infos['backlink']) ? $infos['backlink'] : '',
                 'charset'    => !empty($infos['charsets']) ? implode(', ', $infos['charsets']) : '',
             ];

--- a/templates/engines.html
+++ b/templates/engines.html
@@ -76,7 +76,7 @@
         </tr>
         <tr>
             <td><label for="engineParameter">{{ 'ReferrersManager_Parameters'|translate }} {{
-                'ReferrersManager_CommaSeparated'|translate }}*:</label></td>
+                'ReferrersManager_CommaSeparated'|translate }}:</label></td>
             <td><input type="text" ng-model="newEngineData['parameters']" id="engineParameter"/></td>
         </tr>
         <tr>


### PR DESCRIPTION
The "Parameters" field is not mandatory in code, so leaving it empty will be accepted, but causes getDefinitions to fail, as it expects parameters to by an array.

This fix does the following:
1. Removes the asterisk for mandatory in the template.
2. Adds parameters as an empty array if the string is empty.
3. Handles incorrect data-type when calling getDefinitions, to ensure working functionality, if a definition with empty string parameters have already been added.